### PR TITLE
Remove name collision between equityExternalLinks and externalLinks.

### DIFF
--- a/python/lsapi.py
+++ b/python/lsapi.py
@@ -46,7 +46,7 @@ class lsapi:
         # The number of external quity links to the url.
         # Free? Yes
         # Response code:  ueid
-        externalLinks                 = 32
+        equityExternalLinks           = 32
         # The number of juice-passing external links to the subdomain.
         # Free? No
         # Response code:  feid
@@ -212,7 +212,7 @@ class lsapi:
         # This is the set of all free fields
         freeCols = (title |
             url |
-            externalLinks |
+            equityExternalLinks |
             links |
             mozRank |
             subdomainMozRank |


### PR DESCRIPTION
@b4hand -- this is related to #18 . What was happening is that the name `externalLinks` was being used both for 32 and 549755813888, so the `freeCols` value ended up not having 32 in its bitmask.