### PR TITLE
Adding in helper fn along with big.js to help with high-precision operations

### DIFF
--- a/javascript/node/batching-urls-sample.js
+++ b/javascript/node/batching-urls-sample.js
@@ -14,9 +14,9 @@ var accessId = process.env.accessId;
 var secretKey = process.env.secretKey;
 
 // `bitFlagExampleValues` is a list of bitFlag values as strings that we'll
-// loop over and sum together using helper function: `getBigMozDictionary`
+// loop over and sum together using helper function: `sumColumnValues`
 var bitFlagExampleValues = ['144115188075855872', '68719476736', '34359738368'];
-var getBigMozDictionary = function(bitFlagValues) {
+var sumColumnValues = function(bitFlagValues) {
   return bitFlagValues.reduce(function (accu, bitFlag) {
     var accuValBig = new bigJs(accu);
     var bitFlagBig = new bigJs(bitFlag);
@@ -29,7 +29,7 @@ var getBigMozDictionary = function(bitFlagValues) {
 // 'cols' is the sum of the bit flags representing each field you want returned.
 // Learn more here: https://moz.com/help/guides/moz-api/mozscape/api-reference/url-metrics
 // returns "144115291155070976"
-var cols = getBigMozDictionary(bitFlagExampleValues);
+var cols = sumColumnValues(bitFlagExampleValues);
 
 // Put each parameter on a new line.
 var stringToSign = accessId + "\n" + expires;

--- a/javascript/node/batching-urls-sample.js
+++ b/javascript/node/batching-urls-sample.js
@@ -3,6 +3,9 @@
 var crypto = require('crypto');
 var http = require('http');
 
+// `bigJs` is used for number-precision when summing the bitFlag values
+var bigJs = require('big.js');
+
 // Set your expires times for several minutes into the future.
 // An expires time excessively far in the future will not be honored by the Mozscape API.
 // Divide the result of Date.now() by 1000 to make sure your result is in seconds.
@@ -10,9 +13,23 @@ var expires = Math.floor((Date.now() / 1000)) + 300;
 var accessId = process.env.accessId;
 var secretKey = process.env.secretKey;
 
+// `bitFlagExampleValues` is a list of bitFlag values as strings that we'll
+// loop over and sum together using helper function: `getBigMozDictionary`
+var bitFlagExampleValues = ['144115188075855872', '68719476736', '34359738368'];
+var getBigMozDictionary = function(bitFlagValues) {
+  return bitFlagValues.reduce(function (accu, bitFlag) {
+    var accuValBig = new bigJs(accu);
+    var bitFlagBig = new bigJs(bitFlag);
+    var bigSum = accuValBig.plus(bitFlagBig);
+
+    return bigSum.toString();
+  }, 0);
+};
+
 // 'cols' is the sum of the bit flags representing each field you want returned.
 // Learn more here: https://moz.com/help/guides/moz-api/mozscape/api-reference/url-metrics
-var cols = "68719476736";
+// returns "144115291155070976"
+var cols = getBigMozDictionary(bitFlagExampleValues);
 
 // Put each parameter on a new line.
 var stringToSign = accessId + "\n" + expires;
@@ -26,7 +43,7 @@ var postData = JSON.stringify(['www.moz.com', 'www.apple.com', 'www.pizza.com'])
 
 var options = {
   hostname: 'lsapi.seomoz.com',
-  path: '/linkscape/url-metrics/?Cols=' + 
+  path: '/linkscape/url-metrics/?Cols=' +
 			cols + '&AccessID=' + accessId +
 			'&Expires=' + expires + '&Signature=' + signature,
   method: 'POST',


### PR DESCRIPTION
## Adding in support for higher-precision operations when summing bitflags.

#### `144115291155070976 !== 144115291155070980`

<img width="542" alt="screen shot 2018-03-11 at 2 16 44 pm" src="https://user-images.githubusercontent.com/5092263/37256860-dc9770d0-2536-11e8-97fd-250bfafcccfc.png">


<img width="1680" alt="screen shot 2018-03-11 at 2 15 58 pm" src="https://user-images.githubusercontent.com/5092263/37256861-ddc4d588-2536-11e8-9080-422698e91100.png">
